### PR TITLE
Issue/sciphone 1208

### DIFF
--- a/Source/UI/SDPullNavigationBar.m
+++ b/Source/UI/SDPullNavigationBar.m
@@ -431,7 +431,7 @@ typedef struct
                 }
 
                 if(action == SDPullNavigationStateEndExpand)    [self expandMenu];
-                if(action == SDPullNavigationStateEndCollapse)  [self collapseMenu];
+                if(action == SDPullNavigationStateEndCollapse)  [self collapseMenuWithCompletion:^{ [self hideMenuContainer]; }];
             }
             completion:^(BOOL finished) {}];
 


### PR DESCRIPTION
This fixes a bug where if you started to drag out the menu but then stopped such that the open gesture didn't trigger, the menu would remain partially visible and block interaction with the underlying view.

@paultiarks @samgrover 
