### PR TITLE
Additional safety regarding network activity indicator.

### DIFF
--- a/Source/WebServices/SDWebService.m
+++ b/Source/WebServices/SDWebService.m
@@ -142,8 +142,10 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
 
 - (void)showNetworkActivityIfNeeded
 {
-    if (_requestCount > 0)
+    if (_requestCount > 0) {
+        [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideNetworkActivity) object:nil];
         [self showNetworkActivity];
+    }
 }
 
 - (void)hideNetworkActivityIfNeeded
@@ -163,7 +165,7 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
 
 - (void)decrementRequests
 {
-	_requestCount--;
+	if (_requestCount > 0) _requestCount--;
 	[self hideNetworkActivityIfNeeded];
 }
 
@@ -775,7 +777,6 @@ NSString *const SDWebServiceError = @"SDWebServiceError";
                 [_dictionaryLock lock]; // NSMutableDictionary isn't thread-safe for writing.
 				[_singleRequests removeObjectForKey:requestName];
                 [_dictionaryLock unlock];
-				[self decrementRequests];
 			}
         }
     }


### PR DESCRIPTION
- Removed a redundant call to -decrementRequests for "single" requests. This
  would happen in the url completion block once the request is canceled. This
  was causing more calls to -decrementRequests than -incrementRequests.
- The request count is unsigned, so prevent underflow by checking for 0.
- Cancel pending delayed calls to hide the indicator when showing it.
